### PR TITLE
Suggestions share dependent intang cost

### DIFF
--- a/inst/gams/scripts/bounds.gms
+++ b/inst/gams/scripts/bounds.gms
@@ -93,3 +93,22 @@ v_refDeviationVar.fx(ref,refVar,reg,t)$(    sameas(ref, "StatusQuo")
 $endif.forceSQ
 
 $endif.matching
+
+
+*** intangible cost adjustment
+* adjustment only for heat pumps
+$ifthen.sequentialRen "%SEQUENTIALREN%" == "TRUE"
+v_specCostRenHS.fx(cost,renAllowedHS(state,hsr),vin,subs,t)$(    vinExists(t,vin)
+                                                             and (   not sameas(hsr,"ehp1")
+                                                                  or not sameas(cost,"intangible")
+                                                                  or tcalib(t)))
+  = p_specCostRenHS(cost,renAllowedHS,vin,subs,t)
+;
+$else.sequentialRen
+v_specCostRen.fx(cost,renAllowed(state,bsr,hsr),vin,subs,t)$(    vinExists(t,vin)
+                                                             and (   not sameas(hsr,"ehp1")
+                                                                  or not sameas(cost,"intangible")
+                                                                  or tcalib(t)))
+  = p_specCostRen(cost,renAllowed,vin,subs,t)
+;
+$endif.sequentialRen

--- a/inst/gams/scripts/declarations.gms
+++ b/inst/gams/scripts/declarations.gms
@@ -68,9 +68,6 @@ priceSensHS(var, region, loc, typ, inc) "price sensitivity of heating system cho
 p_statusQuoPref "preference for replacehing a heating system with the same technology in USD/m2"
 p_statusQuoShare(hs) "share of heating systems that are identically replaced"
 
-o_specCostRen(cost,bs,hs,bsr,hsr,vin,region,loc,typ,inc,ttot) "floor-space specific renovation cost with heat pump intangible cost adjustment [USD/m2]"
-o_specCostRenHS(cost,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "floor-space specific heating system replacement cost with heat pump intangible cost adjustment [USD/m2]"
-
 ;
 
 scalars
@@ -130,6 +127,9 @@ $endif.renCorrect
 ;
 
 positive variables
+v_specCostRen(cost,bs,hs,bsr,hsr,vin,region,loc,typ,inc,ttot) "floor-space specific renovation cost with heat pump intangible cost adjustment [USD/m2]"
+v_specCostRenHS(cost,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "floor-space specific heating system replacement cost with heat pump intangible cost adjustment [USD/m2]"
+
 v_opeCost(region,loc,typ,inc,ttot) "operational cost cash flow in USD/yr"
 v_demCost(region,loc,typ,inc,ttot) "demolition cost cash flow in USD/yr"
 
@@ -140,8 +140,9 @@ v_renovationBS(qty,bs,hs,bsr,vin,region,loc,typ,inc,ttot)   "flow of buildings w
 v_renovationHS(qty,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "flow of buildings with heating system repacement (incl. untouched) [million m2/yr]"
 v_demolition(qty,bs,hs,vin,region,loc,typ,inc,ttot)         "flow of demolished buildings in million m2/yr"
 
-v_factorIntangCostHeatPump(region,loc,typ,inc,ttot)  "factor to scale down intangible costs for heat pumps [1]"
-v_shareHeatPump(region,loc,typ,inc,ttot)             "Share of heat pumps in the stock"
+v_factorIntangCostHeatPump(region,loc,typ,inc,ttot)      "factor to scale down intangible costs for heat pumps [1]"
+v_factorIntangCostHeatPumpNorm(region,loc,typ,inc,ttot)  "factor to scale down intangible costs for heat pumps (normalised: 1 at tcalib) [1]"
+v_shareHeatPump(region,loc,typ,inc,ttot)                 "Share of heat pumps in the stock"
 
 v_dwelSizeStock(vin,region,loc,typ,inc,ttot)        "average dwelling size of the stock [m2/dwel]"
 v_dwelSizeConstruction(region,loc,typ,inc,ttot)     "average dwelling size of newly constructed buildings [m2/dwel]"
@@ -160,14 +161,19 @@ equations
 q_totObj                  "total objective"
 q_obj(region,loc,typ,inc) "objective: discounted system cost + heterogeneity preference"
 
+q_specCostRenHS(cost,bs,hs,hsr,vin,region,loc,typ,inc,ttot)   "floor-space specific renovation cost"
+q_specCostRen(cost,bs,hs,bsr,hsr,vin,region,loc,typ,inc,ttot) "floor-space specific heating system replacement cost"
+
 q_sysCost(region,loc,typ,inc,ttot) "system cost (con + ren + ope + dem)"
 q_conCost(region,loc,typ,inc,ttot) "construction cost"
 q_renCost(region,loc,typ,inc,ttot) "renovation cost"
 q_renCostLinear(region,loc,typ,inc,ttot) "linear renovation cost"
 q_opeCost(region,loc,typ,inc,ttot) "operation cost"
 q_demCost(region,loc,typ,inc,ttot) "demolition cost"
-q_factorIntangCostHeatPump(region,loc,typ,inc,ttot) "factor to scale down intangible costs for heat pumps"
-q_shareHeatPump(region,loc,typ,inc,ttot) "share of heat pumps in stock"
+
+q_factorIntangCostHeatPump(region,loc,typ,inc,ttot)     "factor to scale down intangible costs for heat pumps"
+q_factorIntangCostHeatPumpNorm(region,loc,typ,inc,ttot) "normalised factor to scale down intangible costs for heat pumps"
+q_shareHeatPump(region,loc,typ,inc,ttot)                "share of heat pumps in stock"
 
 q_renovationBS(qty,bs,hs,bsr,vin,region,loc,typ,inc,ttot) "aggregate renovation to building shell retrofit"
 q_renovationHS(qty,bs,hs,hsr,vin,region,loc,typ,inc,ttot) "aggregate renovation to heating system replacement"

--- a/inst/gams/scripts/equations.gms
+++ b/inst/gams/scripts/equations.gms
@@ -70,8 +70,35 @@ q_renCost(subs,t)..
   v_renCost(subs,t)
   =e=
   sum(vin$vinExists(t,vin),
-$ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE" !! TODO: this might be generalisable
     sum(cost,
+$ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE"
+      sum(renAllowedBS,
+        v_renovationBS("area",renAllowedBS,vin,subs,t)
+        * p_specCostRenBS(cost,renAllowedBS,vin,subs,t)
+      )
+      +
+      sum(renAllowedHS(bs, hs, hsr),
+        v_renovationHS("area",renAllowedHS,vin,subs,t)
+        * v_specCostRenHS(cost,renAllowedHS,vin,subs,t)
+      )
+$else.sequentialRen
+    sum(renAllowed(bs, hs, bsr, hsr),
+      v_renovation("area",renAllowed,vin,subs,t)
+      * v_specCostRen(cost,renAllowed,vin,subs,t)
+    )
+$endif.sequentialRen
+    )
+  )
+;
+
+
+* Linear renovation cost without adjustment of intangible costs (lp)
+q_renCostLinear(subs,t)..
+  v_renCost(subs,t)
+  =e=
+  sum(vin$vinExists(t,vin),
+    sum(cost,
+$ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE"
       sum(renAllowedBS,
         v_renovationBS("area",renAllowedBS,vin,subs,t)
         * p_specCostRenBS(cost,renAllowedBS,vin,subs,t)
@@ -80,80 +107,78 @@ $ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE" !! TODO: this might be genera
       sum(renAllowedHS(bs, hs, hsr),
         v_renovationHS("area",renAllowedHS,vin,subs,t)
         * p_specCostRenHS(cost,renAllowedHS,vin,subs,t)
-        * (
-          (v_factorIntangCostHeatPump(subs, t)
-          / (sum(tcalibLast, v_factorIntangCostHeatPump(subs, tcalibLast)) + epsilon))$(sameas(hsr, "ehp1")
-                                                        and sameas(cost, "intangible")
-                                                        and not tcalib(t))
-          + 1$(not sameas(hsr, "ehp1")
-               or not sameas(cost, "intangible")
-               or tcalib(t))
-        )
       )
-    )
 $else.sequentialRen
-    sum((renAllowed(bs, hs, bsr, hsr), cost),
+    sum(renAllowed(bs, hs, bsr, hsr),
       v_renovation("area",renAllowed,vin,subs,t)
       * p_specCostRen(cost,renAllowed,vin,subs,t)
-      * (
-          (v_factorIntangCostHeatPump(subs, t)
-          / (sum(tcalibLast, v_factorIntangCostHeatPump(subs, tcalibLast)) + epsilon))$(sameas(hsr, "ehp1")
-                                                        and sameas(cost, "intangible")
-                                                        and not tcalib(t))
-          + 1$(not sameas(hsr, "ehp1")
-               or not sameas(cost, "intangible")
-               or tcalib(t))
-        )
     )
 $endif.sequentialRen
+    )
   )
 ;
 
+
+* Compute heat pump stock share
+q_shareHeatPump(subs, ttot)..
+  v_shareHeatPump(subs, ttot)
+  * sum((bs, hs, vin)$vinExists(ttot,vin),
+    v_stock("area", bs, hs, vin, subs, ttot)
+  )
+  =e=
+  sum((bs, vin)$vinExists(ttot,vin),
+    v_stock("area", bs, "ehp1", vin, subs, ttot)
+  )
+;
+
+
 * Compute factor to adjust intangible cost of heat pumps as S-curve of the current heat pump stock share
-q_factorIntangCostHeatPump(subs, t)..
-  v_factorIntangCostHeatPump(subs, t)
+q_factorIntangCostHeatPump(subs, ttot)..
+  v_factorIntangCostHeatPump(subs, ttot)
   =e=
   1 - (1 - p_factorIntangParams("minshare"))
   * 1 / (
     1 + exp(
-      -(v_shareHeatPump(subs, t-1) - p_factorIntangParams("midpoint"))
+      -(v_shareHeatPump(subs, ttot-1) - p_factorIntangParams("midpoint"))
       / p_factorIntangParams("scale")
     )
   )
 ;
 
-* Compute heat pump stock share
-q_shareHeatPump(subs, t)..
-  v_shareHeatPump(subs, t) * sum((bs, hs, vin)$vinExists(t,vin), v_stock("area", bs, hs, vin, subs, t))
+
+* scaling factor for intangible cost that can scale down intangible cost of heat pumps after calibration periods
+
+q_factorIntangCostHeatPumpNorm(subs, t)..
+  v_factorIntangCostHeatPumpNorm(subs, t)
+  * sum(tcalibLast, v_factorIntangCostHeatPump(subs, tcalibLast))
   =e=
-  sum((bs, vin)$vinExists(t,vin), v_stock("area", bs, "ehp1", vin, subs, t))
+  v_factorIntangCostHeatPump(subs, t)
 ;
 
-* Linear renovation cost without adjustment of intangible costs (lp)
-q_renCostLinear(subs,t)..
-  v_renCost(subs,t)
+* rescale specific intangible cost
+q_specCostRenHS(cost, bs, hs, hsr, vin, subs, t)$(    renAllowedHS(bs,hs,hsr)
+                                                  and vinExists(t,vin)
+                                                  and sameas(hsr,"ehp1")
+                                                  and sameas(cost,"intangible")
+                                                  and not tcalib(t))..
+  v_specCostRenHS(cost, bs, hs, hsr, vin, subs, t)
   =e=
-  sum(vin$vinExists(t,vin),
-$ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE"
-    sum(cost,
-      sum(renAllowedBS,
-        v_renovationBS("area",renAllowedBS,vin,subs,t)
-        * p_specCostRenBS(cost,renAllowedBS,vin,subs,t)
-      )
-      +
-      sum(renAllowedHS,
-        v_renovationHS("area",renAllowedHS,vin,subs,t)
-        * p_specCostRenHS(cost,renAllowedHS,vin,subs,t)
-      )
-    )
-$else.sequentialRen
-    sum((renAllowed, cost),
-      v_renovation("area",renAllowed,vin,subs,t)
-      * p_specCostRen(cost,renAllowed,vin,subs,t)
-    )
-$endif.sequentialRen
-  )
+  p_specCostRenHS(cost,bs, hs, hsr, vin,subs,t)
+  * v_factorIntangCostHeatPumpNorm(subs, t)
 ;
+
+q_specCostRen(cost, bs, hs, bsr, hsr, vin, subs, t)$(    renAllowed(bs,hs,bsr,hsr)
+                                                     and vinExists(t,vin)
+                                                     and sameas(hsr,"ehp1")
+                                                     and sameas(cost,"intangible")
+                                                     and not tcalib(t))..
+  v_specCostRen(cost, bs, hs, bsr, hsr, vin, subs, t)
+  =e=
+  p_specCostRen(cost,bs,hs,bsr,hsr,vin,subs,t)
+  * v_factorIntangCostHeatPumpNorm(subs, t)
+;
+
+
 
 
 *** operation cost -------------------------------------------------------------

--- a/inst/gams/scripts/output.gms
+++ b/inst/gams/scripts/output.gms
@@ -29,30 +29,6 @@ if(card(ErrStock) + card(ErrConstruction) + card(ErrRenovation) + card(ErrRenova
   abort "Variable entries that should not exist are greater zero. abort.gdx written";
 );
 
-*** write final realized specific renovation costs (including reduction factor for heat pumps)
-$ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE"
-o_specCostRenHS(cost, bs, hs, hsr, vin, subs, t) = p_specCostRenHS(cost,bs, hs, hsr, vin,subs,t)
-        * (
-          (v_factorIntangCostHeatPump.l(subs, t)
-          / (sum(tcalibLast, v_factorIntangCostHeatPump.l(subs, tcalibLast)) + epsilon))$(sameas(hsr, "ehp1")
-                                                        and sameas(cost, "intangible")
-                                                        and not tcalib(t))
-          + 1$(not sameas(hsr, "ehp1")
-               or not sameas(cost, "intangible")
-               or tcalib(t))
-        )
-$else.sequentialRen
-o_specCostRen(cost, bs, hs, bsr, hsr, vin, subs, t) = p_specCostRen(cost,bs,hs,bsr,hsr,vin,subs,t)
-      * (
-          (v_factorIntangCostHeatPump.l(subs, t)
-          / (sum(tcalibLast, v_factorIntangCostHeatPump.l(subs, tcalibLast)) + epsilon))$(sameas(hsr, "ehp1")
-                                                        and sameas(cost, "intangible")
-                                                        and not tcalib(t))
-          + 1$(not sameas(hsr, "ehp1")
-               or not sameas(cost, "intangible")
-               or tcalib(t))
-        )
-$endif.sequentialRen
 
 
 *** write results

--- a/inst/gams/scripts/solve.gms
+++ b/inst/gams/scripts/solve.gms
@@ -51,17 +51,20 @@ model fullSysNLP "full system linear optimisation"
   q_opeCost
   q_demCost
   q_factorIntangCostHeatPump
+  q_factorIntangCostHeatPumpNorm
   q_shareHeatPump
 $ifthen.sequentialRen  "%SEQUENTIALREN%" == "TRUE"
   q_stockBal1
   q_stockBal2
   q_stockBal3
+  q_specCostRenHS
 $else.sequentialRen
   q_stockBalNext
   q_stockBalPrev
   q_renovationBS
   q_renovationHS
   q_entropyRenFrom
+  q_specCostRen  
 $endif.sequentialRen
 $ifthen.notFixedBuildings not "%FIXEDBUILDINGS%" == "TRUE"
   q_housingDemand


### PR DESCRIPTION
This PR mainly contains some suggested restructuring of the intangible heat pump cost implementation. See if you like it. You can also consider just parts of it. Technically, I'm unsure if we aim to merge this or you it may just serve as a source of inspiration.

This code runs through and produces the same results as yours within small tolerances. The less granular HP share does change results of course, but that's an extra commit. 

Besides restructuring, there are relevant enhancements or bugfixes:

- filtering for existing vintages to avoid initialising inexistent variable entries
- Using `ttot` instead of `t` in some equations is necessary to make this work with if the last calibration time step is historic.